### PR TITLE
[Work in progress] Adding PreviousLoopbackCalculator to improve framerates

### DIFF
--- a/hand_tracker.py
+++ b/hand_tracker.py
@@ -92,7 +92,7 @@ class HandTracker():
        
     @staticmethod
     def _sigm(x):
-        return 1 / (1 + np.exp(-x) )
+        return 1 / (1 + np.exp(-x.astype('float64')).astype('float32') )
     
     @staticmethod
     def _pad1(x):


### PR DESCRIPTION
Trying  to add the `PreviousLoopbackCalculator` to the wrapper. For now, I have added the `hand_flag` and used it in conjunction with the previous `source` from the palm interpreter to avoid having to run the palm interpreter all the time. Need to implement the addition of recalculating the `source` based on the current join prediction, i.e. the `DetectionsToRectsCalculator` and `RectTransformationCalculator` in https://github.com/google/mediapipe/blob/master/mediapipe/graphs/hand_tracking/subgraphs/hand_landmark_cpu.pbtxt 

edit: related to the discussion on frame rates in #6 